### PR TITLE
Initialize result slices as empty arrays so JSON output is `[]` not `null`

### DIFF
--- a/main.go
+++ b/main.go
@@ -462,7 +462,7 @@ func handleCompletion(server *Server, req RPCRequest) {
 		}
 	}
 
-	var items []CompletionItem
+	items := []CompletionItem{}
 	seenItems := make(map[string]bool)
 
 	server.mutex.Lock()
@@ -582,7 +582,7 @@ func handleWorkspaceSymbol(server *Server, req RPCRequest) {
 	}
 
 	query := params.Query
-	var symbols []SymbolInformation
+	symbols := []SymbolInformation{}
 
 	server.mutex.Lock()
 	defer server.mutex.Unlock()
@@ -645,7 +645,7 @@ func handleDocumentSymbol(server *Server, req RPCRequest) {
 	server.mutex.Lock()
 	defer server.mutex.Unlock()
 
-	var symbols []SymbolInformation
+	symbols := []SymbolInformation{}
 
 	tagEntries := server.tagEntries
 	if server.isRootlessFile(normalizedURI) {

--- a/main_test.go
+++ b/main_test.go
@@ -688,6 +688,52 @@ func TestDocumentSymbolsOrderedByLine(t *testing.T) {
 	}
 }
 
+func TestCompletionEmptyItemsReturnsArrayNotNull(t *testing.T) {
+	tempDir := t.TempDir()
+	sourcePath := filepath.Join(tempDir, "empty.go")
+	fileURI := pathToFileURI(sourcePath)
+
+	server := newTestServer(t)
+	server.rootURI = pathToFileURI(tempDir)
+	// Buffer with a word at the cursor so handleCompletion enters the main
+	// path (rather than the early-return for "no current word").
+	server.cache.content[fileURI] = strings.Split("xyz\n", "\n")
+	// No tags: nothing can match the loop, so the result slice stays empty.
+	server.tagEntries = nil
+
+	params := CompletionParams{
+		TextDocument: PositionParams{URI: fileURI},
+		Position:     Position{Line: 0, Character: 3},
+	}
+	paramsBytes, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+
+	id := json.RawMessage("1")
+	req := RPCRequest{ID: &id, Params: paramsBytes}
+	var output bytes.Buffer
+	server.output = &output
+	handleCompletion(server, req)
+
+	raw := output.String()
+	if strings.Contains(raw, `"items":null`) {
+		t.Fatalf("CompletionList.items must be `[]`, never `null` (LSP spec):\n%s", raw)
+	}
+	if !strings.Contains(raw, `"items":[]`) {
+		t.Fatalf("expected `\"items\":[]` in response, got:\n%s", raw)
+	}
+
+	resp := parseLSPResult(t, raw)
+	var list CompletionList
+	if err := json.Unmarshal(resp.Result, &list); err != nil {
+		t.Fatalf("unmarshal CompletionList: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("expected empty items, got %d", len(list.Items))
+	}
+}
+
 func TestNormalizePath(t *testing.T) {
 	baseDir := t.TempDir()
 


### PR DESCRIPTION
Three handlers declare their result slices with `var ... []T`, which leaves
them as nil if the loop body never appends. When marshalled to JSON, a nil
Go slice becomes `null`, not `[]`.

For [`textDocument/completion`](https://github.com/netmute/ctags-lsp/blob/fe3d1f8490c5e7db38725b6e847472b9a63bacfc/main.go#L465), this is a spec violation. [`CompletionList.items`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion) is typed as `CompletionItem[]`, non-nullable. Strict LSP clients can choke on `{"isIncomplete": false, "items": null}`. I hit this in [blink.cmp](https://github.com/Saghen/blink.cmp).

For [`workspace/symbol`](https://github.com/netmute/ctags-lsp/blob/fe3d1f8490c5e7db38725b6e847472b9a63bacfc/main.go#L585) and [`textDocument/documentSymbol`](https://github.com/netmute/ctags-lsp/blob/fe3d1f8490c5e7db38725b6e847472b9a63bacfc/main.go#L648), top-level `null` is technically valid LSP, but `[]` is the more common convention. The same one-line change keeps the three handlers consistent.

### Diff

```go
- var items   []CompletionItem
+ items   := []CompletionItem{}

- var symbols []SymbolInformation   // workspace/symbol
+ symbols := []SymbolInformation{}

- var symbols []SymbolInformation   // documentSymbol
+ symbols := []SymbolInformation{}
```

No behavior change in Go (`len`, `range`, `append` all behave identically;
no `nil` comparisons in the codebase). Tiny extra heap allocation per
request (~24 bytes for a slice header). Existing tests pass.